### PR TITLE
fixed the unable to edit frm after print preview on quotes

### DIFF
--- a/pdf_on_submit/hooks.py
+++ b/pdf_on_submit/hooks.py
@@ -12,17 +12,17 @@ app_email = "raffael@alyf.de"
 app_license = "GPLv3"
 
 
-'''
-Monkey Patch Technique
-'''
-import frappe.workflow.doctype.workflow_action.workflow_action
-import pdf_on_submit.monkey_patch 
-'''
-Monkey patching the standard process workflow actions with custom
-process workflow actions to supress email notification for a particular
-workflow state.
-'''
-frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions = pdf_on_submit.monkey_patch.cust_process_workflow_actions
+# '''
+# Monkey Patch Technique
+# '''
+# import frappe.workflow.doctype.workflow_action.workflow_action
+# import pdf_on_submit.monkey_patch 
+# '''
+# Monkey patching the standard process workflow actions with custom
+# process workflow actions to supress email notification for a particular
+# workflow state.
+# '''
+# frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions = pdf_on_submit.monkey_patch.cust_process_workflow_actions
 
 # Includes in <head>
 # ------------------

--- a/pdf_on_submit/public/js/print_restrict.js
+++ b/pdf_on_submit/public/js/print_restrict.js
@@ -1,12 +1,12 @@
 /**
  * ============================================================================
- * Custom Print Page Toolbar Override — Restrict Draft Quotation Downloads
+ * Custom Print Page Toolbar Override — Restrict Not Approved Quotation Downloads
  * ============================================================================
  * Purpose:
  *   One of our clients uses a workflow-enabled Quotation process where:
  *     - A Quotation in **Request For Approval** state must NOT be printed or downloaded.
  *     - Printing/downloading should only be allowed once the document has moved
- *       beyond the Draft stage (e.g., after approval or submission).
+ *       beyond the Draft or Pending stage (e.g., after approval or self approval).
  *
  *   This script enforces that restriction on the Print Page (`/app/print/...`).
  *
@@ -25,6 +25,9 @@
  *       → Limit scope and prevent global leakage.
  *       → Execute the override logic immediately.
  *   - Calls the original `set_title()` method after injecting the custom logic.
+ * 	 - Uses jQuery `.filter()` with `.text().trim()` to target buttons by their
+ *     visible text (innertext) — this means we are matching **what the user sees on screen**,
+ *     not `data-label` attributes or icon references.
  *   - Injected using the `page_js` hook for the Print Page.
  *
  * File:
@@ -63,47 +66,43 @@
 
 		frappe.ui.form.PrintView.prototype.set_title = function () {
 			try {
-				// (bug-fix note) : for more robust checking we are reading the innertext as well
-				// in the element along with href
-				// @params - iaConfig (list) - conatining label and href link
+				// (bug-fix note) : both form's Save and Print was primary action button, 
+				// so for more robust checking we are reading the innertext as well
+				// in the element
 				// @params - iAction (str) - "hide" or "show"
-				function fnToggleButtons(iaConfig, iAction) {
-					$('button.btn.btn-default.btn-sm.ellipsis').filter(function () {
-						// used some() instead of find() because it return boolean
-						return iaConfig.some(idConfig => 
-							idConfig.label === $(this).text().trim() && 
-							idConfig.href === $(this).find('use').attr('href'));
-					})[iAction]();
+				function fnToggleButtons( iAction) {
+					 // Primary "Print" button
+					 $('button.btn.btn-primary.btn-sm.primary-action')
+					 .filter(function () {
+						 return $(this).text().trim() === __('Print');
+					 })[iAction]();
+
+				 // Secondary buttons: Full Page & PDF (with translation support)
+				 $('button.btn.btn-default.btn-sm.ellipsis').filter(function () {
+					 return [__('Full Page'), __('PDF')].includes($(this).text().trim());
+				 })[iAction]();
 				}
+
 				// Use `workflow state` instead of `status` for reliability
 				if (this.frm.doctype === "Quotation" && 
 					this.frm.doc.workflow_state && 
 					(!["Approved", "Self Approved"].includes(this.frm.doc.workflow_state))) {
-					// Hide Print Button
-					// (bug-fix note): both form and Print was primary action button
-					// so we have added the data-label has well
-					$(`.btn.btn-primary.btn-sm.primary-action[data-label="${__('Print')}"]`).hide();
 
-					
-					// the Full Page and PDF doesn't has a data-label similar to Print
+					// Hide Print Button
+					// $(".btn.btn-primary.btn-sm.primary-action").hide();
+
 					// // Hide Full Page Button
 					// $('button:has(use[href="#icon-full-page"])').hide();
 
 					// // Hide PDF Button
 					// $('button:has(use[href="#icon-small-file"])').hide();
-					fnToggleButtons([
-						{ label: "Full Page", href: "#icon-full-page" },
-						{ label: "PDF", href: "#icon-small-file" }
-					], "hide");
+					fnToggleButtons("hide");
 					
 				} else {
-					$(`.btn.btn-primary.btn-sm.primary-action[data-label="${__('Print')}"]`).show();
+					// $(".btn.btn-primary.btn-sm.primary-action").show();
 					// $('button:has(use[href="#icon-full-page"])').show();
 					// $('button:has(use[href="#icon-small-file"])').show();
-					fnToggleButtons([
-						{ label: "Full Page", href: "#icon-full-page" },
-						{ label: "PDF", href: "#icon-small-file" }
-					], "show");
+					fnToggleButtons("show");
 				}
 				// Call the original method safely
 				fnOriginalSetTitle.call(this);

--- a/pdf_on_submit/public/js/print_restrict.js
+++ b/pdf_on_submit/public/js/print_restrict.js
@@ -63,6 +63,18 @@
 
 		frappe.ui.form.PrintView.prototype.set_title = function () {
 			try {
+				// (bug-fix note) : for more robust checking we are reading the innertext as well
+				// in the element along with href
+				// @params - iaConfig (list) - conatining label and href link
+				// @params - iAction (str) - "hide" or "show"
+				function fnToggleButtons(iaConfig, iAction) {
+					$('button.btn.btn-default.btn-sm.ellipsis').filter(function () {
+						// used some() instead of find() because it return boolean
+						return iaConfig.some(idConfig => 
+							idConfig.label === $(this).text().trim() && 
+							idConfig.href === $(this).find('use').attr('href'));
+					})[iAction]();
+				}
 				// Use `workflow state` instead of `status` for reliability
 				if (this.frm.doctype === "Quotation" && 
 					this.frm.doc.workflow_state && 
@@ -72,21 +84,31 @@
 					// so we have added the data-label has well
 					$(`.btn.btn-primary.btn-sm.primary-action[data-label="${__('Print')}"]`).hide();
 
-					// Hide Full Page Button
-					$('button:has(use[href="#icon-full-page"])').hide();
+					
+					// the Full Page and PDF doesn't has a data-label similar to Print
+					// // Hide Full Page Button
+					// $('button:has(use[href="#icon-full-page"])').hide();
 
-					// Hide PDF Button
-					$('button:has(use[href="#icon-small-file"])').hide();
+					// // Hide PDF Button
+					// $('button:has(use[href="#icon-small-file"])').hide();
+					fnToggleButtons([
+						{ label: "Full Page", href: "#icon-full-page" },
+						{ label: "PDF", href: "#icon-small-file" }
+					], "hide");
+					
 				} else {
 					$(`.btn.btn-primary.btn-sm.primary-action[data-label="${__('Print')}"]`).show();
-					$('button:has(use[href="#icon-full-page"])').show();
-					$('button:has(use[href="#icon-small-file"])').show();
+					// $('button:has(use[href="#icon-full-page"])').show();
+					// $('button:has(use[href="#icon-small-file"])').show();
+					fnToggleButtons([
+						{ label: "Full Page", href: "#icon-full-page" },
+						{ label: "PDF", href: "#icon-small-file" }
+					], "show");
 				}
-
 				// Call the original method safely
 				fnOriginalSetTitle.call(this);
-			} catch (err) {
-				console.log("Custom print button override failed:", err);
+			} catch (error) {
+				console.log("Custom print button override failed:", error);
 			}
 		};
 	} else {

--- a/pdf_on_submit/public/js/print_restrict.js
+++ b/pdf_on_submit/public/js/print_restrict.js
@@ -64,9 +64,13 @@
 		frappe.ui.form.PrintView.prototype.set_title = function () {
 			try {
 				// Use `workflow state` instead of `status` for reliability
-				if (this.frm.doctype === "Quotation" && (!["Approved", "Self Approved"].includes(this.frm.doc.workflow_state))) {
+				if (this.frm.doctype === "Quotation" && 
+					this.frm.doc.workflow_state && 
+					(!["Approved", "Self Approved"].includes(this.frm.doc.workflow_state))) {
 					// Hide Print Button
-					$(".btn.btn-primary.btn-sm.primary-action").hide();
+					// (bug-fix note): both form and Print was primary action button
+					// so we have added the data-label has well
+					$(`.btn.btn-primary.btn-sm.primary-action[data-label="${__('Print')}"]`).hide();
 
 					// Hide Full Page Button
 					$('button:has(use[href="#icon-full-page"])').hide();
@@ -74,7 +78,7 @@
 					// Hide PDF Button
 					$('button:has(use[href="#icon-small-file"])').hide();
 				} else {
-					$(".btn.btn-primary.btn-sm.primary-action").show();
+					$(`.btn.btn-primary.btn-sm.primary-action[data-label="${__('Print')}"]`).show();
 					$('button:has(use[href="#icon-full-page"])').show();
 					$('button:has(use[href="#icon-small-file"])').show();
 				}


### PR DESCRIPTION
After the custom solution done for hiding PRINT options for pending or draft quotes, the user unable to edit the quotation in draft after coming out of the print preview