### PR TITLE
ISS-2026-00074 - Wrong Item Filtering

### DIFF
--- a/pdf_on_submit/api.py
+++ b/pdf_on_submit/api.py
@@ -117,7 +117,7 @@ def fn_get_item_search_configuration():
 	except frappe.DoesNotExistError:
 		return []
 	
-def fn_get_priority_order_clause(ia_item_search_priority, i_txt, i_description_only_condition=""):
+def fn_get_priority_order_clause(ia_item_search_priority, i_txt):
 	"""Generate SQL CASE condition for Item priority ordering."""
 
 	# Apply Item template prioritization only during actual user search
@@ -152,28 +152,26 @@ def fn_get_priority_order_clause(ia_item_search_priority, i_txt, i_description_o
 	if not la_case_conditions:
 		return ""
 
-	# return f"""
-	# 	case
-	# 		{' '.join(la_case_conditions)}
-	# 		else 999
-	# 	end,
-	# """
-	l_priority_case = f"""
-	case
-		{' '.join(la_case_conditions)}
-		else 999
-	end
+	return f"""
+		case
+			{' '.join(la_case_conditions)}
+			else 999
+		end,
 	"""
 
-	if not i_description_only_condition:
-		return l_priority_case + ","
+def fn_get_search_match_order_clause(i_txt):
+	"""Generate SQL CASE condition for Item search relevance."""
+
+	if not i_txt or not i_txt.strip("%"):
+		return ""
 
 	return f"""
-	case
-		when {i_description_only_condition}
-		then 999
-		else {l_priority_case}
-	end,
+		case
+			when tabItem.item_code like %(txt)s then 1
+			when tabItem.item_name like %(txt)s then 2
+			when tabItem.description like %(txt)s then 3
+			else 999
+		end,
 	"""
 
 '''
@@ -233,9 +231,6 @@ def custom_item_query(doctype, txt, searchfield, start, page_len, filters, as_di
 		for l_field in [searchfield or "name", "item_code", "item_group", "item_name"]
 		if l_field not in la_searchfields
 	]
-
-	la_searchfields_list = la_searchfields.copy()
-
 	# Generate SQL LIKE conditions for all searchable fields
 	la_searchfields = " or ".join([l_field + " like %(txt)s" for l_field in la_searchfields])
 
@@ -289,27 +284,11 @@ def custom_item_query(doctype, txt, searchfield, start, page_len, filters, as_di
 	# to prioritize preferred Item template variants in search results
 	la_item_search_priority = fn_get_item_search_configuration()
 
-	# Build condition to identify Items matching only through description
-	l_description_only_condition = ""
-
-	if "description" in la_searchfields_list:
-		la_non_description_conditions = [
-			f"{l_field} LIKE %(txt)s"
-			for l_field in la_searchfields_list
-			if l_field != "description"
-		]
-
-		l_description_only_condition = f"""
-			tabItem.description LIKE %(txt)s
-			AND NOT (
-				{' OR '.join(la_non_description_conditions)}
-			)
-		"""
+	l_order_match_priority = fn_get_search_match_order_clause(txt)
 
 	l_order_priority = fn_get_priority_order_clause(
 		la_item_search_priority,
-		txt,
-		l_description_only_condition
+		txt
 	)
 	return frappe.db.sql(
 		"""select
@@ -323,6 +302,7 @@ def custom_item_query(doctype, txt, searchfield, start, page_len, filters, as_di
 				{l_description_cond})
 			{fcond} {mcond}
 		order by
+			{l_order_match_priority}
 			{l_order_priority}
 			if(locate(%(_txt)s, name), locate(%(_txt)s, name), 99999),
 			if(locate(%(_txt)s, item_name), locate(%(_txt)s, item_name), 99999),
@@ -335,6 +315,7 @@ def custom_item_query(doctype, txt, searchfield, start, page_len, filters, as_di
 			mcond=get_match_cond(l_doctype).replace("%", "%%"),
 			l_description_cond=l_description_cond,
 			l_order_priority=l_order_priority,
+			l_order_match_priority=l_order_match_priority
 		),
 		{
 			"today": nowdate(),

--- a/pdf_on_submit/api.py
+++ b/pdf_on_submit/api.py
@@ -160,7 +160,13 @@ def fn_get_priority_order_clause(ia_item_search_priority, i_txt):
 	"""
 
 def fn_get_search_match_order_clause(i_txt):
-	"""Generate SQL CASE condition for Item search relevance."""
+	"""
+	Issue id: ISS-2026-00074 - Wrong Item Filtering
+	Prioritize direct Item Code and Item Name matches over Description matches.
+
+	For example, when searching for "Service", the main Service Item should
+	appear before variants whose Description contains "Service".
+	"""
 
 	if not i_txt or not i_txt.strip("%"):
 		return ""
@@ -284,6 +290,7 @@ def custom_item_query(doctype, txt, searchfield, start, page_len, filters, as_di
 	# to prioritize preferred Item template variants in search results
 	la_item_search_priority = fn_get_item_search_configuration()
 
+	# Give lower priority to Items matched only through their Description.
 	l_order_match_priority = fn_get_search_match_order_clause(txt)
 
 	l_order_priority = fn_get_priority_order_clause(

--- a/pdf_on_submit/api.py
+++ b/pdf_on_submit/api.py
@@ -291,7 +291,7 @@ def custom_item_query(doctype, txt, searchfield, start, page_len, filters, as_di
 	la_item_search_priority = fn_get_item_search_configuration()
 
 	# Give lower priority to Items matched only through their Description.
-	l_order_match_priority = fn_get_search_match_order_clause(txt)
+	l_order_match_priority = fn_get_search_match_order_clause(txt) #ISS-2026-00074
 
 	l_order_priority = fn_get_priority_order_clause(
 		la_item_search_priority,

--- a/pdf_on_submit/api.py
+++ b/pdf_on_submit/api.py
@@ -117,7 +117,7 @@ def fn_get_item_search_configuration():
 	except frappe.DoesNotExistError:
 		return []
 	
-def fn_get_priority_order_clause(ia_item_search_priority, i_txt):
+def fn_get_priority_order_clause(ia_item_search_priority, i_txt, i_description_only_condition=""):
 	"""Generate SQL CASE condition for Item priority ordering."""
 
 	# Apply Item template prioritization only during actual user search
@@ -152,11 +152,28 @@ def fn_get_priority_order_clause(ia_item_search_priority, i_txt):
 	if not la_case_conditions:
 		return ""
 
+	# return f"""
+	# 	case
+	# 		{' '.join(la_case_conditions)}
+	# 		else 999
+	# 	end,
+	# """
+	l_priority_case = f"""
+	case
+		{' '.join(la_case_conditions)}
+		else 999
+	end
+	"""
+
+	if not i_description_only_condition:
+		return l_priority_case + ","
+
 	return f"""
-		case
-			{' '.join(la_case_conditions)}
-			else 999
-		end,
+	case
+		when {i_description_only_condition}
+		then 999
+		else {l_priority_case}
+	end,
 	"""
 
 '''
@@ -216,6 +233,9 @@ def custom_item_query(doctype, txt, searchfield, start, page_len, filters, as_di
 		for l_field in [searchfield or "name", "item_code", "item_group", "item_name"]
 		if l_field not in la_searchfields
 	]
+
+	la_searchfields_list = la_searchfields.copy()
+
 	# Generate SQL LIKE conditions for all searchable fields
 	la_searchfields = " or ".join([l_field + " like %(txt)s" for l_field in la_searchfields])
 
@@ -269,9 +289,27 @@ def custom_item_query(doctype, txt, searchfield, start, page_len, filters, as_di
 	# to prioritize preferred Item template variants in search results
 	la_item_search_priority = fn_get_item_search_configuration()
 
+	# Build condition to identify Items matching only through description
+	l_description_only_condition = ""
+
+	if "description" in la_searchfields_list:
+		la_non_description_conditions = [
+			f"{l_field} LIKE %(txt)s"
+			for l_field in la_searchfields_list
+			if l_field != "description"
+		]
+
+		l_description_only_condition = f"""
+			tabItem.description LIKE %(txt)s
+			AND NOT (
+				{' OR '.join(la_non_description_conditions)}
+			)
+		"""
+
 	l_order_priority = fn_get_priority_order_clause(
 		la_item_search_priority,
-		txt
+		txt,
+		l_description_only_condition
 	)
 	return frappe.db.sql(
 		"""select


### PR DESCRIPTION
**Observation**

Users were unable to find Items by searching individual words from the Item Name, such as “earth” or “PT100”. The Item was only displayed when the complete Item Name was entered.

**Root Cause**

The Item search prioritized the configured Item Templates from Quotation Presets before considering the relevance of the search match. As a result, variants whose Description contained the search term were first grouped and sorted based on the configured template priority, pushing the actual Item Name match further down the results.

**Fix**

Updated the search ordering to prioritize the match relevance first:

Item Code → Item Name → Description

The configured Item Template priority from Quotation Presets is then applied within the relevant results, ensuring that direct Item Name matches appear before variants matched only through their Description.

**Changed Object:**

- pdf_on_submit/api.py