### PR TITLE
US-2026-1363 - Catalog Items At The First Place - ISS-2026-00078 

### DIFF
--- a/pdf_on_submit/api.py
+++ b/pdf_on_submit/api.py
@@ -118,49 +118,65 @@ def fn_get_item_search_configuration():
 		return []
 	
 def fn_get_priority_order_clause(ia_item_search_priority, i_txt):
-	"""Generate SQL CASE condition for Item priority ordering."""
+	"""
+	Generate SQL CASE condition for Item priority ordering.
 
-	# Apply Item template and is_catalog_item prioritization only during actual user search
-	# to avoid reordering default Item dropdown results
+	Two-tier priority:
+	  Tier 1 (best):     variant_of matches the configured template AND
+	                      (if configured) is_catalog_item is also set.
+	  Tier 2 (fallback): variant_of matches the configured template,
+	                      but the catalog-item flag requirement isn't met.
+	                      Still ranked ahead of items whose template
+	                      isn't configured at all.
+	"""
+
 	if not (ia_item_search_priority and i_txt.strip("%")):
 		return ""
+
+	# Gap large enough that every Tier 1 match (across ALL configured
+	# templates) outranks every Tier 2 match. Bump this up only if you
+	# ever configure 500+ priority rows.
+	TIER2_OFFSET = 500
 
 	la_case_conditions = []
 	la_processed_rules = set()
 
-	# Build dynamic CASE conditions using configured Item priority sequence
 	for ld_row in ia_item_search_priority:
-		# Skip empty Item Template
 		if not ld_row.item_template:
 			continue
 
-		# Treat (Item Template, Is Catalog) as a unique rule
 		l_rule = (ld_row.item_template, cint(ld_row.is_catalog_item))
 		if l_rule in la_processed_rules:
 			continue
-
 		la_processed_rules.add(l_rule)
-		# Escape Item template values and is_catalog_item values before injecting into SQL CASE condition
-		# to safely handle special characters and avoid SQL syntax errors
-		# ex: ABC's Cable --> 'ABC\'s Cable'
-		l_condition = (
-            f"ifnull(tabItem.variant_of, '') = "
-            f"{frappe.db.escape(ld_row.item_template)}"
-        )
-		if ld_row.is_catalog_item:
-			l_condition += (
-                " and ifnull(tabItem.is_catalog_item, 0) = 1"
-            )
 
-        # Apply configured template priority ONLY when
-        # the Item Name also matches the search text.
-		l_condition += " and tabItem.item_name like %(txt)s"
-		la_case_conditions.append(
-            f"""
-                when {l_condition}
-                then {ld_row.idx}
-            """
-        )
+		l_template_cond = (
+			f"ifnull(tabItem.variant_of, '') = "
+			f"{frappe.db.escape(ld_row.item_template)}"
+		)
+
+		if ld_row.is_catalog_item:
+			# Tier 1: template + catalog flag both match
+			la_case_conditions.append(f"""
+				when {l_template_cond}
+					and ifnull(tabItem.is_catalog_item, 0) = 1
+					and tabItem.item_name like %(txt)s
+				then {ld_row.idx}
+			""")
+			# Tier 2: right template, catalog flag not set on this item —
+			# still better than an unconfigured template.
+			la_case_conditions.append(f"""
+				when {l_template_cond}
+					and tabItem.item_name like %(txt)s
+				then {TIER2_OFFSET + ld_row.idx}
+			""")
+		else:
+			# No catalog requirement configured — template match alone is Tier 1.
+			la_case_conditions.append(f"""
+				when {l_template_cond}
+					and tabItem.item_name like %(txt)s
+				then {ld_row.idx}
+			""")
 
 	if not la_case_conditions:
 		return ""
@@ -171,7 +187,7 @@ def fn_get_priority_order_clause(ia_item_search_priority, i_txt):
 			else 999
 		end,
 	"""
-
+	
 def fn_get_search_match_order_clause(i_txt):
 	"""
 	Issue id: ISS-2026-00074 - Wrong Item Filtering

--- a/pdf_on_submit/api.py
+++ b/pdf_on_submit/api.py
@@ -146,8 +146,7 @@ def fn_get_priority_order_clause(ia_item_search_priority, i_txt):
 		l_condition = f"""
 			(
 				(
-					tabItem.item_code LIKE %(txt)s
-					OR tabItem.item_name LIKE %(txt)s
+					tabItem.item_name LIKE %(txt)s
 				)
 				AND ifnull(tabItem.variant_of, '') =
 					{frappe.db.escape(ld_row.item_template)}

--- a/pdf_on_submit/api.py
+++ b/pdf_on_submit/api.py
@@ -116,7 +116,7 @@ def fn_get_item_search_configuration():
 	# Ignore error if Quotation Presets doctype does not exist
 	except frappe.DoesNotExistError:
 		return []
-	
+# Generate SQL ORDER BY expressions for Item priority ordering based on configured templates and catalog requirements.	
 def fn_get_priority_order_clause(ia_item_search_priority, i_txt):
 	"""
 	Generate SQL ORDER BY expressions for Item priority ordering.
@@ -124,7 +124,7 @@ def fn_get_priority_order_clause(ia_item_search_priority, i_txt):
 	Template order comes FIRST — it always wins, no exceptions.
 	Catalog-item match is used ONLY to break ties within the same template.
 
-	Example with DTTHCZ2N (idx=1) and DTTHZ2N (idx=2), both catalog-required:
+	Example: DTTHCZ2N (idx=1) and DTTHZ2N (idx=2), both catalog-required:
 	  1. DTTHCZ2N + catalog match
 	  2. DTTHCZ2N + catalog mismatch
 	  3. DTTHZ2N  + catalog match
@@ -142,28 +142,29 @@ def fn_get_priority_order_clause(ia_item_search_priority, i_txt):
 	la_catalog_when = []
 	la_processed_rules = set()
 
+	# Iterate through configured Item template priority rules and generate SQL CASE expressions
 	for ld_row in ia_item_search_priority:
+		# Skip rows where no template was set.
 		if not ld_row.item_template:
 			continue
-
+		# Skip if this exact (template, catalog-required) combo was already processed.
 		l_rule = (ld_row.item_template, cint(ld_row.is_catalog_item))
 		if l_rule in la_processed_rules:
 			continue
 		la_processed_rules.add(l_rule)
-
+		# Base condition: is this item a variant of the configured template,
+		# and does its name match the search text?
 		l_template_match = (
 			f"ifnull(tabItem.variant_of, '') = "
 			f"{frappe.db.escape(ld_row.item_template)}"
 			f" and tabItem.item_name like %(txt)s"
 		)
-
 		# Template rank never depends on catalog status.
 		la_template_when.append(f"when {l_template_match} then {ld_row.idx}")
 
 		if ld_row.is_catalog_item:
-			# Catalog required: catalog-matched items of this template rank 0 (best),
-			# catalog-missing items of this SAME template rank 1 (worse, but still
-			# tied to this template's slot — never jumps to another template).
+			# Catalog match required for this template:
+			# rank 0 = template matched AND catalog flag set (best within this template).
 			la_catalog_when.append(f"when {l_template_match} and ifnull(tabItem.is_catalog_item, 0) = 1 then 0")
 			la_catalog_when.append(f"when {l_template_match} then 1")
 		else:
@@ -171,12 +172,15 @@ def fn_get_priority_order_clause(ia_item_search_priority, i_txt):
 			# can appear in any order within this template's slot.
 			la_catalog_when.append(f"when {l_template_match} then 0")
 
+	# If nothing was actually configured/matched, skip ordering entirely.
 	if not la_template_when:
 		return "", ""
-
+	# Generate SQL CASE expressions for template and catalog ordering
 	l_template_clause = f"case {' '.join(la_template_when)} else 999 end,"
 	l_catalog_clause = f"case {' '.join(la_catalog_when)} else 0 end,"
 
+	# The caller must place l_template_clause BEFORE l_catalog_clause in ORDER BY
+	# for template-first, catalog-as-tiebreaker behavior to work.
 	return l_template_clause, l_catalog_clause
 
 '''

--- a/pdf_on_submit/api.py
+++ b/pdf_on_submit/api.py
@@ -133,7 +133,9 @@ def fn_get_priority_order_clause(ia_item_search_priority, i_txt):
 	if not (ia_item_search_priority and i_txt.strip("%")):
 		return ""
 
-	#Push Condition 2 scores above all Condition 1 scores, so Condition 1 always wins.
+	# Add an offset for fallback matches so they always rank below
+	# the preferred catalog-item matches, while still ranking above
+	# items whose template does not match any configured priority.
 	CONDITION2_OFFSET = len(ia_item_search_priority) + 1
 
 	la_case_conditions = []
@@ -154,22 +156,26 @@ def fn_get_priority_order_clause(ia_item_search_priority, i_txt):
 		)
 
 		if ld_row.is_catalog_item:
-			# Condition 1: template matches AND item is flagged as catalog item.
+			# Condition 1 (preferred):
+			# Template matches + item is a catalog item.
+			# Uses the original priority index, so these results are ranked first.
 			la_case_conditions.append(f"""
 				when {l_template_cond}
 					and ifnull(tabItem.is_catalog_item, 0) = 1
 					and tabItem.item_name like %(txt)s
 				then {ld_row.idx}
 			""")
-			# Condition 2: template matches, but catalog flag is missing.
-			# Still ranked better than an unconfigured/unrelated template.
+			# Condition 2 (fallback):
+			# Template matches, but the item is not required to be a catalog item.
+			# The offset lowers its priority, but keeps it above unrelated templates.
 			la_case_conditions.append(f"""
 				when {l_template_cond}
 					and tabItem.item_name like %(txt)s
 				then {CONDITION2_OFFSET + ld_row.idx}
 			""")
 		else:
-			# No catalog flag required — template match alone is good enough (Condition 1).
+			# Catalog match is not required for this rule.
+			# A template match therefore receives the configured priority directly.
 			la_case_conditions.append(f"""
 				when {l_template_cond}
 					and tabItem.item_name like %(txt)s

--- a/pdf_on_submit/api.py
+++ b/pdf_on_submit/api.py
@@ -143,25 +143,24 @@ def fn_get_priority_order_clause(ia_item_search_priority, i_txt):
 		# Escape Item template values and is_catalog_item values before injecting into SQL CASE condition
 		# to safely handle special characters and avoid SQL syntax errors
 		# ex: ABC's Cable --> 'ABC\'s Cable'
-		l_condition = f"""
-			(
-				(
-					tabItem.item_name LIKE %(txt)s
-				)
-				AND ifnull(tabItem.variant_of, '') =
-					{frappe.db.escape(ld_row.item_template)}
-			)
-		"""
-		# Match Catalog Items only when configured
+		l_condition = (
+            f"ifnull(tabItem.variant_of, '') = "
+            f"{frappe.db.escape(ld_row.item_template)}"
+        )
 		if ld_row.is_catalog_item:
-			l_condition += " and ifnull(tabItem.is_catalog_item, 0) = 1"
+			l_condition += (
+                " and ifnull(tabItem.is_catalog_item, 0) = 1"
+            )
 
+        # Apply configured template priority ONLY when
+        # the Item Name also matches the search text.
+		l_condition += " and tabItem.item_name like %(txt)s"
 		la_case_conditions.append(
-			f"""
-				when {l_condition}
-				then {ld_row.idx}
-			"""
-		)
+            f"""
+                when {l_condition}
+                then {ld_row.idx}
+            """
+        )
 
 	if not la_case_conditions:
 		return ""
@@ -323,7 +322,8 @@ def custom_item_query(doctype, txt, searchfield, start, page_len, filters, as_di
 				{l_description_cond})
 			{fcond} {mcond}
 		order by
-			{l_order_priority}
+			if(tabItem.item_name like %(txt)s, 1, 2),
+    		{l_order_priority}
 			if(locate(%(_txt)s, name), locate(%(_txt)s, name), 99999),
 			if(locate(%(_txt)s, item_name), locate(%(_txt)s, item_name), 99999),
 			idx desc,

--- a/pdf_on_submit/api.py
+++ b/pdf_on_submit/api.py
@@ -142,14 +142,21 @@ def fn_get_priority_order_clause(ia_item_search_priority, i_txt):
 	la_processed_rules = set()
 
 	for ld_row in ia_item_search_priority:
+		# Skip empty Item Template
 		if not ld_row.item_template:
 			continue
-
+		
+		# Treat (Item Template, Is Catalog) as a unique rule
 		l_rule = (ld_row.item_template, cint(ld_row.is_catalog_item))
+
 		if l_rule in la_processed_rules:
 			continue
+		
 		la_processed_rules.add(l_rule)
 
+		# Escape Item template values and is_catalog_item values before injecting into SQL CASE condition
+		# to safely handle special characters and avoid SQL syntax errors
+		# ex: ABC's Cable --> 'ABC\'s Cable'
 		l_template_cond = (
 			f"ifnull(tabItem.variant_of, '') = "
 			f"{frappe.db.escape(ld_row.item_template)}"

--- a/pdf_on_submit/api.py
+++ b/pdf_on_submit/api.py
@@ -133,9 +133,7 @@ def fn_get_priority_order_clause(ia_item_search_priority, i_txt):
 	if not (ia_item_search_priority and i_txt.strip("%")):
 		return ""
 
-	# Guarantees every Condition 1 match outranks every Condition 2 match,
-	# regardless of how many priority rows are configured — offset always
-	# exceeds the highest possible idx in this list.
+	#Push Condition 2 scores above all Condition 1 scores, so Condition 1 always wins.
 	CONDITION2_OFFSET = len(ia_item_search_priority) + 1
 
 	la_case_conditions = []
@@ -156,22 +154,22 @@ def fn_get_priority_order_clause(ia_item_search_priority, i_txt):
 		)
 
 		if ld_row.is_catalog_item:
-			# Condition 1 checks template + catalog flag both match
+			# Condition 1: template matches AND item is flagged as catalog item.
 			la_case_conditions.append(f"""
 				when {l_template_cond}
 					and ifnull(tabItem.is_catalog_item, 0) = 1
 					and tabItem.item_name like %(txt)s
 				then {ld_row.idx}
 			""")
-			# Condition 2 checks right template, catalog flag not set on this item —
-			# still better than an unconfigured template .
+			# Condition 2: template matches, but catalog flag is missing.
+			# Still ranked better than an unconfigured/unrelated template.
 			la_case_conditions.append(f"""
 				when {l_template_cond}
 					and tabItem.item_name like %(txt)s
 				then {CONDITION2_OFFSET + ld_row.idx}
 			""")
 		else:
-			# No catalog requirement configured — template match alone is Tier 1.
+			# No catalog flag required — template match alone is good enough (Condition 1).
 			la_case_conditions.append(f"""
 				when {l_template_cond}
 					and tabItem.item_name like %(txt)s
@@ -315,7 +313,6 @@ def custom_item_query(doctype, txt, searchfield, start, page_len, filters, as_di
 				{l_description_cond})
 			{fcond} {mcond}
 		order by
-			if(tabItem.item_name like %(txt)s, 1, 2),
     		{l_order_priority}
 			if(locate(%(_txt)s, name), locate(%(_txt)s, name), 99999),
 			if(locate(%(_txt)s, item_name), locate(%(_txt)s, item_name), 99999),

--- a/pdf_on_submit/api.py
+++ b/pdf_on_submit/api.py
@@ -119,86 +119,65 @@ def fn_get_item_search_configuration():
 	
 def fn_get_priority_order_clause(ia_item_search_priority, i_txt):
 	"""
-	Generate SQL CASE condition for Item priority ordering.
+	Generate SQL ORDER BY expressions for Item priority ordering.
 
-	Two-condition priority:
-	  Condition 1 (best):     variant_of matches the configured template AND
-	                          (if configured) is_catalog_item is also set.
-	  Condition 2 (fallback): variant_of matches the configured template,
-	                          but the catalog-item flag requirement isn't met.
-	                          Still ranked ahead of items whose template
-	                          isn't configured at all.
+	Template order comes FIRST — it always wins, no exceptions.
+	Catalog-item match is used ONLY to break ties within the same template.
+
+	Example with DTTHCZ2N (idx=1) and DTTHZ2N (idx=2), both catalog-required:
+	  1. DTTHCZ2N + catalog match
+	  2. DTTHCZ2N + catalog mismatch
+	  3. DTTHZ2N  + catalog match
+	  4. DTTHZ2N  + catalog mismatch
+	  5. anything not matching a configured template
 	"""
 
+	# Nothing configured, or nothing typed — skip entirely.
 	if not (ia_item_search_priority and i_txt.strip("%")):
-		return ""
+		return "", ""
 
-	# Add an offset for fallback matches so they always rank below
-	# the preferred catalog-item matches, while still ranking above
-	# items whose template does not match any configured priority.
-	CONDITION2_OFFSET = len(ia_item_search_priority) + 1
-
-	la_case_conditions = []
+	# Column 1: which template matched — this alone decides the main order.
+	la_template_when = []
+	# Column 2: does it satisfy the catalog requirement — only used as a tiebreaker.
+	la_catalog_when = []
 	la_processed_rules = set()
 
 	for ld_row in ia_item_search_priority:
-		# Skip empty Item Template
 		if not ld_row.item_template:
 			continue
 
-		# Treat (Item Template, Is Catalog) as a unique rule
 		l_rule = (ld_row.item_template, cint(ld_row.is_catalog_item))
-
 		if l_rule in la_processed_rules:
 			continue
-
 		la_processed_rules.add(l_rule)
 
-		# Escape Item template values and is_catalog_item values before injecting into SQL CASE condition
-		# to safely handle special characters and avoid SQL syntax errors
-		# ex: ABC's Cable --> 'ABC\'s Cable'
-		l_template_cond = (
+		l_template_match = (
 			f"ifnull(tabItem.variant_of, '') = "
 			f"{frappe.db.escape(ld_row.item_template)}"
+			f" and tabItem.item_name like %(txt)s"
 		)
 
+		# Template rank never depends on catalog status.
+		la_template_when.append(f"when {l_template_match} then {ld_row.idx}")
+
 		if ld_row.is_catalog_item:
-			# Condition 1 (preferred):
-			# Template matches + item is a catalog item.
-			# Uses the original priority index, so these results are ranked first.
-			la_case_conditions.append(f"""
-				when {l_template_cond}
-					and ifnull(tabItem.is_catalog_item, 0) = 1
-					and tabItem.item_name like %(txt)s
-				then {ld_row.idx}
-			""")
-			# Condition 2 (fallback):
-			# Template matches, but the item is not required to be a catalog item.
-			# The offset lowers its priority, but keeps it above unrelated templates.
-			la_case_conditions.append(f"""
-				when {l_template_cond}
-					and tabItem.item_name like %(txt)s
-				then {CONDITION2_OFFSET + ld_row.idx}
-			""")
+			# Catalog required: catalog-matched items of this template rank 0 (best),
+			# catalog-missing items of this SAME template rank 1 (worse, but still
+			# tied to this template's slot — never jumps to another template).
+			la_catalog_when.append(f"when {l_template_match} and ifnull(tabItem.is_catalog_item, 0) = 1 then 0")
+			la_catalog_when.append(f"when {l_template_match} then 1")
 		else:
-			# Catalog match is not required for this rule.
-			# A template match therefore receives the configured priority directly.
-			la_case_conditions.append(f"""
-				when {l_template_cond}
-					and tabItem.item_name like %(txt)s
-				then {ld_row.idx}
-			""")
+			# Catalog not required for this template — catalog / non-catalog items
+			# can appear in any order within this template's slot.
+			la_catalog_when.append(f"when {l_template_match} then 0")
 
-	if not la_case_conditions:
-		return ""
+	if not la_template_when:
+		return "", ""
 
-	return f"""
-		case
-			{' '.join(la_case_conditions)}
-			else 999
-		end,
-	"""
-	
+	l_template_clause = f"case {' '.join(la_template_when)} else 999 end,"
+	l_catalog_clause = f"case {' '.join(la_catalog_when)} else 0 end,"
+
+	return l_template_clause, l_catalog_clause
 
 '''
 Custom Item search query used to prioritize Item search results
@@ -310,7 +289,7 @@ def custom_item_query(doctype, txt, searchfield, start, page_len, filters, as_di
 	# to prioritize preferred Item template variants in search results
 	la_item_search_priority = fn_get_item_search_configuration()
 
-	l_order_priority = fn_get_priority_order_clause(
+	l_order_template, l_order_catalog = fn_get_priority_order_clause(
 		la_item_search_priority,
 		txt
 	)
@@ -326,7 +305,8 @@ def custom_item_query(doctype, txt, searchfield, start, page_len, filters, as_di
 				{l_description_cond})
 			{fcond} {mcond}
 		order by
-    		{l_order_priority}
+			{l_order_template}
+			{l_order_catalog}
 			if(locate(%(_txt)s, name), locate(%(_txt)s, name), 99999),
 			if(locate(%(_txt)s, item_name), locate(%(_txt)s, item_name), 99999),
 			idx desc,
@@ -337,7 +317,8 @@ def custom_item_query(doctype, txt, searchfield, start, page_len, filters, as_di
 			fcond=get_filters_cond(l_doctype, filters, la_conditions).replace("%", "%%"),
 			mcond=get_match_cond(l_doctype).replace("%", "%%"),
 			l_description_cond=l_description_cond,
-			l_order_priority=l_order_priority,
+			l_order_template=l_order_template,
+			l_order_catalog=l_order_catalog,
 		),
 		{
 			"today": nowdate(),

--- a/pdf_on_submit/api.py
+++ b/pdf_on_submit/api.py
@@ -145,13 +145,13 @@ def fn_get_priority_order_clause(ia_item_search_priority, i_txt):
 		# Skip empty Item Template
 		if not ld_row.item_template:
 			continue
-		
+
 		# Treat (Item Template, Is Catalog) as a unique rule
 		l_rule = (ld_row.item_template, cint(ld_row.is_catalog_item))
 
 		if l_rule in la_processed_rules:
 			continue
-		
+
 		la_processed_rules.add(l_rule)
 
 		# Escape Item template values and is_catalog_item values before injecting into SQL CASE condition

--- a/pdf_on_submit/api.py
+++ b/pdf_on_submit/api.py
@@ -143,10 +143,16 @@ def fn_get_priority_order_clause(ia_item_search_priority, i_txt):
 		# Escape Item template values and is_catalog_item values before injecting into SQL CASE condition
 		# to safely handle special characters and avoid SQL syntax errors
 		# ex: ABC's Cable --> 'ABC\'s Cable'
-		l_condition = (
-			f"ifnull(tabItem.variant_of, '') = {frappe.db.escape(ld_row.item_template)}"
-		)
-
+		l_condition = f"""
+			(
+				(
+					tabItem.item_code LIKE %(txt)s
+					OR tabItem.item_name LIKE %(txt)s
+				)
+				AND ifnull(tabItem.variant_of, '') =
+					{frappe.db.escape(ld_row.item_template)}
+			)
+		"""
 		# Match Catalog Items only when configured
 		if ld_row.is_catalog_item:
 			l_condition += " and ifnull(tabItem.is_catalog_item, 0) = 1"
@@ -300,7 +306,7 @@ def custom_item_query(doctype, txt, searchfield, start, page_len, filters, as_di
 	la_item_search_priority = fn_get_item_search_configuration()
 
 	# Give lower priority to Items matched only through their Description.
-	l_order_match_priority = fn_get_search_match_order_clause(txt) #ISS-2026-00074
+	# l_order_match_priority = fn_get_search_match_order_clause(txt) #ISS-2026-00074
 
 	l_order_priority = fn_get_priority_order_clause(
 		la_item_search_priority,
@@ -318,7 +324,6 @@ def custom_item_query(doctype, txt, searchfield, start, page_len, filters, as_di
 				{l_description_cond})
 			{fcond} {mcond}
 		order by
-			{l_order_match_priority}
 			{l_order_priority}
 			if(locate(%(_txt)s, name), locate(%(_txt)s, name), 99999),
 			if(locate(%(_txt)s, item_name), locate(%(_txt)s, item_name), 99999),
@@ -331,7 +336,6 @@ def custom_item_query(doctype, txt, searchfield, start, page_len, filters, as_di
 			mcond=get_match_cond(l_doctype).replace("%", "%%"),
 			l_description_cond=l_description_cond,
 			l_order_priority=l_order_priority,
-			l_order_match_priority=l_order_match_priority
 		),
 		{
 			"today": nowdate(),

--- a/pdf_on_submit/api.py
+++ b/pdf_on_submit/api.py
@@ -121,22 +121,22 @@ def fn_get_priority_order_clause(ia_item_search_priority, i_txt):
 	"""
 	Generate SQL CASE condition for Item priority ordering.
 
-	Two-tier priority:
-	  Tier 1 (best):     variant_of matches the configured template AND
-	                      (if configured) is_catalog_item is also set.
-	  Tier 2 (fallback): variant_of matches the configured template,
-	                      but the catalog-item flag requirement isn't met.
-	                      Still ranked ahead of items whose template
-	                      isn't configured at all.
+	Two-condition priority:
+	  Condition 1 (best):     variant_of matches the configured template AND
+	                          (if configured) is_catalog_item is also set.
+	  Condition 2 (fallback): variant_of matches the configured template,
+	                          but the catalog-item flag requirement isn't met.
+	                          Still ranked ahead of items whose template
+	                          isn't configured at all.
 	"""
 
 	if not (ia_item_search_priority and i_txt.strip("%")):
 		return ""
 
-	# Gap large enough that every Tier 1 match (across ALL configured
-	# templates) outranks every Tier 2 match. Bump this up only if you
-	# ever configure 500+ priority rows.
-	TIER2_OFFSET = 500
+	# Guarantees every Condition 1 match outranks every Condition 2 match,
+	# regardless of how many priority rows are configured — offset always
+	# exceeds the highest possible idx in this list.
+	CONDITION2_OFFSET = len(ia_item_search_priority) + 1
 
 	la_case_conditions = []
 	la_processed_rules = set()
@@ -156,19 +156,19 @@ def fn_get_priority_order_clause(ia_item_search_priority, i_txt):
 		)
 
 		if ld_row.is_catalog_item:
-			# Tier 1: template + catalog flag both match
+			# Condition 1 checks template + catalog flag both match
 			la_case_conditions.append(f"""
 				when {l_template_cond}
 					and ifnull(tabItem.is_catalog_item, 0) = 1
 					and tabItem.item_name like %(txt)s
 				then {ld_row.idx}
 			""")
-			# Tier 2: right template, catalog flag not set on this item —
-			# still better than an unconfigured template.
+			# Condition 2 checks right template, catalog flag not set on this item —
+			# still better than an unconfigured template .
 			la_case_conditions.append(f"""
 				when {l_template_cond}
 					and tabItem.item_name like %(txt)s
-				then {TIER2_OFFSET + ld_row.idx}
+				then {CONDITION2_OFFSET + ld_row.idx}
 			""")
 		else:
 			# No catalog requirement configured — template match alone is Tier 1.
@@ -188,26 +188,6 @@ def fn_get_priority_order_clause(ia_item_search_priority, i_txt):
 		end,
 	"""
 	
-def fn_get_search_match_order_clause(i_txt):
-	"""
-	Issue id: ISS-2026-00074 - Wrong Item Filtering
-	Prioritize direct Item Code and Item Name matches over Description matches.
-
-	For example, when searching for "Service", the main Service Item should
-	appear before variants whose Description contains "Service".
-	"""
-
-	if not i_txt or not i_txt.strip("%"):
-		return ""
-
-	return f"""
-		case
-			when tabItem.item_name like %(txt)s then 1
-			when tabItem.item_code like %(txt)s then 2
-			when tabItem.description like %(txt)s then 3
-			else 999
-		end,
-	"""
 
 '''
 Custom Item search query used to prioritize Item search results
@@ -318,9 +298,6 @@ def custom_item_query(doctype, txt, searchfield, start, page_len, filters, as_di
 	# Fetch Item search Sort Order configuration from Quotation Presets
 	# to prioritize preferred Item template variants in search results
 	la_item_search_priority = fn_get_item_search_configuration()
-
-	# Give lower priority to Items matched only through their Description.
-	# l_order_match_priority = fn_get_search_match_order_clause(txt) #ISS-2026-00074
 
 	l_order_priority = fn_get_priority_order_clause(
 		la_item_search_priority,


### PR DESCRIPTION
Observation:
The Item search prioritized results only by Item Template and did not support prioritizing Catalog Items within the configured Item Template in quotation presets.

Fix:
Added a Catalog checkbox to the Quotation Presets's Item Search Sort Order configuration table. When the Catalog checkbox is enabled for an Item Template, matching Catalog Items for that Item Template are given higher priority and appear first in the search results. If the checkbox is not enabled, the search follows the existing Item Template priority and returns all matching Items.

Changes File: pdf_on_submit/api.py

Story reference: US-2026-1363
Issue reference: ISS-2026-00078