### PR TITLE
US-2026-1363 - Catalog Items At The First Place - ISS-2026-00078 & ISS-2026-00074

### DIFF
--- a/pdf_on_submit/api.py
+++ b/pdf_on_submit/api.py
@@ -135,7 +135,7 @@ def fn_get_priority_order_clause(ia_item_search_priority, i_txt):
 	# Nothing configured, or nothing typed — skip entirely.
 	if not (ia_item_search_priority and i_txt.strip("%")):
 		return "", ""
-
+	#<<ISS-2026-00074 & ISS-2026-00078
 	# Column 1: which template matched — this alone decides the main order.
 	la_template_when = []
 	# Column 2: does it satisfy the catalog requirement — only used as a tiebreaker.
@@ -182,6 +182,7 @@ def fn_get_priority_order_clause(ia_item_search_priority, i_txt):
 	# The caller must place l_template_clause BEFORE l_catalog_clause in ORDER BY
 	# for template-first, catalog-as-tiebreaker behavior to work.
 	return l_template_clause, l_catalog_clause
+  #>>ISS-2026-00074 & ISS-2026-00078
 
 '''
 Custom Item search query used to prioritize Item search results
@@ -202,6 +203,10 @@ preferred Item templates first in search results.
 
 If no preferred template is configured, the query follows the
 default ERPNext Item ordering behavior.
+
+ISS-2026-00078 - catalog items at the first place by creating offer in Lens
+ISS-2026-00074 - Wrong Item Filtering
+The above issues are combined one.
 '''
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
@@ -293,10 +298,13 @@ def custom_item_query(doctype, txt, searchfield, start, page_len, filters, as_di
 	# to prioritize preferred Item template variants in search results
 	la_item_search_priority = fn_get_item_search_configuration()
 
+	#<<ISS-2026-00074 & ISS-2026-00078
 	l_order_template, l_order_catalog = fn_get_priority_order_clause(
 		la_item_search_priority,
 		txt
 	)
+	#<<ISS-2026-00074 & ISS-2026-00078 
+	# Added l_order_template and l_order_catalog to ORDER BY clause to prioritize preferred Item templates first in search results
 	return frappe.db.sql(
 		"""select
 			tabItem.name {l_columns}


### PR DESCRIPTION
### Issue : ISS-2026-00078 - Catalog Items At The First Place
Observation:
The Item search prioritized results only by Item Template and did not support prioritizing Catalog Items within the configured Item Template in quotation presets.

Fix:
Added a Catalog checkbox to the Quotation Presets's Item Search Sort Order configuration table. When the Catalog checkbox is enabled for an Item Template, matching Catalog Items for that Item Template are given higher priority and appear first in the search results. If the checkbox is not enabled, the search follows the existing Item Template priority and returns all matching Items.

Changes File: pdf_on_submit/api.py

Story reference: US-2026-1363

### Issue : ISS-2026-00074 - Wrong filtering Item
**Observation**

Users were unable to find Items by searching individual words from the Item Name, such as “earth” or “PT100”. The Item was only displayed when the complete Item Name was entered.

**Root Cause**

The Item search prioritized the configured Item Templates from Quotation Presets before considering the relevance of the search match. As a result, variants whose Description contained the search term were first grouped and sorted based on the configured template priority, pushing the actual Item Name match further down the results.

**Fix**

Updated the search ordering to prioritize the match relevance first:
Item Code → Item Name → Description
The configured Item Template priority from Quotation Presets is then applied within the relevant results, ensuring that direct Item Name matches appear before variants matched only through their Description.

Changed Object:  pdf_on_submit/api.py
